### PR TITLE
Fix version conflicts caused by PR#231

### DIFF
--- a/Harpoon.Tests/Harpoon.Tests.csproj
+++ b/Harpoon.Tests/Harpoon.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -20,11 +20,11 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" Version="3.1.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="3.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.TestHost from 3.1.7 to 5.0.8. [(PR#231)](https://github.com/Poltuu/Harpoon/pull/231).
Hope this fix can help you.

Best regards,
sucrose